### PR TITLE
Make extractify command line friendly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,4 +5,3 @@ extend: "eslint:recommended"
 rules:
   indent: [2, 4, {SwitchCase: 1}]
   quotes: [2, 'single']
-  dot-notation: [2, {allowKeywords: false}]

--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ browserify -p [ extractify OPTIONS ]
 
 ### options
 ``` js
-// Sample OPTIONS
+// Sampe command line OPTIONS
+browserify test/files/main.js -p ['extractify' --lazy [ [ --entries [ './test/files/dep4.js' './test/files/dep6.js' ] --outfile './test/lazy_bundle/lazy_bundle.js' ] ] --bundleMapOption [ --injectSoft false --dest 'test/lazy_bundle/map.json' ] ] > test/lazy_bundle/main_bundle.js
+
+// Sample api OPTIONS
 {
-  {
-    bundleMapOption: {
-      injectSoft: false,
-      dest: 'lazy_bundle/map.json'
-    }
+  bundleMapOption: {
+    injectSoft: false,
+    dest: 'lazy_bundle/map.json'
   },
   lazy: [
     {
@@ -67,9 +68,10 @@ b.plugin('extractify', {
   lazy: [
     {
       entries: [
-        './files/dep4.js'
+        './files/dep4.js',
+        './files/dep6.js'
       ],
-      outfile: './bundles/lazy_bundle_dep4.js'
+      outfile: './bundles/lazy_bundle.js'
     }
   ]
 });

--- a/lib/process_options.js
+++ b/lib/process_options.js
@@ -1,0 +1,48 @@
+function handleUnderScore(obj, prop) {
+    if (!Array.isArray(obj[prop]) && obj[prop]._ && Array.isArray(obj[prop]._)) {
+        if (obj[prop]._.length === 0) {
+            obj[prop] = [obj[prop]];
+        } else {
+            obj[prop] = obj[prop]._;
+        }
+        delete obj[prop]._;
+    }
+    return obj;
+}
+
+module.exports = function processOptions(opts) {
+    if (!(opts && opts.lazy)) {
+        throw new Error('Please provide lazy option. Refer to extractify documentation for available options');
+    }
+
+    if (opts._) {
+        //command line
+        if (!opts._.length) {
+            delete opts._;
+        }
+        if (opts.bundleMapOption && opts.bundleMapOption._) {
+            delete opts.bundleMapOption._;
+        }
+
+    } else {
+        // api or grunt
+        return opts;
+    }
+
+    // process commandline options
+    opts = handleUnderScore(opts, 'lazy');
+    for (var i = 0; i < opts.lazy.length; i++) {
+        if (opts.lazy[i].entries && typeof opts.lazy[i].entries === 'string') {
+            // handle single entry
+            opts.lazy[i].entries = [opts.lazy[i].entries];
+        } else {
+            // handle multiple entries
+            opts.lazy[i] = handleUnderScore(opts.lazy[i], 'entries');
+        }
+
+        delete opts.lazy[i]._;
+    }
+
+    return opts;
+};
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extractify",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Browserify plugin to extract code to be lazy loaded into separate bundles",
   "repository": {
     "type": "git",

--- a/test/command_line_options.js
+++ b/test/command_line_options.js
@@ -1,0 +1,104 @@
+/* Copyright 2016, Yahoo Inc.
+   Copyrights licensed under the MIT License.
+   See the accompanying LICENSE file for terms. */
+
+var test = require('tap').test;
+
+test('commandline options', function(t) {
+    var processOptions = require('../lib/process_options');
+    var opt1 = {
+        '_': [],
+        'lazy': {
+            '_': [{
+                '_': [],
+                'entries': {
+                    '_': ['foo1', 'bar1']
+                },
+                'outfile': 'oo1'
+            }, {
+                '_': [],
+                'entries': {
+                    '_': ['foo12', 'bar2']
+                },
+                'outfile': 'oo2'
+            }]
+        },
+        'bundleMapOption': {
+            '_': [],
+            'dest': 'boo',
+            'basedir': 'moo'
+        }
+    };
+    var expected1 = {
+        'lazy': [{
+            'entries': ['foo1', 'bar1'],
+            'outfile': 'oo1'
+        }, {
+            'entries': ['foo12', 'bar2'],
+            'outfile': 'oo2'
+        }],
+        'bundleMapOption': {
+            'dest': 'boo',
+            'basedir': 'moo'
+        }
+    };
+    var opt2 = {
+        '_': [],
+        'lazy': {
+            '_': [{
+                '_': [],
+                'entries': {
+                    '_': ['foo1', 'bar1']
+                },
+                'outfile': 'oo1'
+            }]
+        }
+    };
+    var expected2 = {
+        'lazy': [{
+            'entries': ['foo1', 'bar1'],
+            'outfile': 'oo1'
+        }]
+    };
+    var opt3 = {
+        '_': [],
+        'lazy': {
+            '_': [{
+                '_': [],
+                'entries': {
+                    '_': ['foo1', 'bar1']
+                },
+                'outfile': 'oo1'
+            }]
+        }
+    };
+    var expected3 = {
+        'lazy': [{
+            'entries': ['foo1', 'bar1'],
+            'outfile': 'oo1'
+        }]
+    };
+    var opt4 = {
+        '_': [],
+        'lazy': {
+            '_': [],
+            'entries': 'foo1',
+            'output': 'oo1'
+        }
+    };
+    var expected4 = {
+        'lazy': [{
+            'entries': ['foo1'],
+            'output': 'oo1'
+        }]
+    };
+
+    t.plan(5);
+    t.same(processOptions(opt1), expected1);
+    t.same(processOptions(opt2), expected2);
+    t.same(processOptions(opt3), expected3);
+    t.same(processOptions(opt4), expected4);
+    t.throws(function() {
+        processOptions({});
+    });
+});


### PR DESCRIPTION
This PR makes extractify command line friendly with browserify. All following use cases covered:
``` js
browserify main.js -p [./extractify.js --lazy [ [ --entries [ foo1 bar1 ] --outfile oo1 ]  [ --entries [ foo12 bar2 ] --outfile oo2 ] ] --bundleMapOption [ --dest boo --basedir moo ] ]
browserify main.js -p [./extractify.js --lazy [ [ --entries [ foo1 bar1 ] --outfile oo1 ]  [ --entries [ foo12 bar2 ] --outfile oo2 ] ] ]
browserify main.js -p [./extractify.js --lazy [ [ --entries [ foo1 ] --outfile oo1 ] [ --entries [ foo12 ] --outfile oo2 ] ] ]
browserify main.js -p [./extractify.js --lazy [ [ --entries [ foo1 bar1 ] --outfile oo1 ] ] ]
browserify main.js -p [./extractify.js --lazy [ [ --entries [ foo1 ] --outfile oo1 ] ] ]

browserify main.js -p [./extractify.js --lazy [--entries foo1 --entries bar1 --output oo1] --lazy [--entries foo2 --entries bar2 --output oo2] --bundleMapOption [ --dest boo --basedir moo ] ]
browserify main.js -p [./extractify.js --lazy [--entries foo1 --entries bar1 --output oo1] --lazy [--entries foo2 --entries bar2 --output oo2] ]
browserify main.js -p [./extractify.js --lazy [--entries foo1 --output oo1] --lazy [--entries foo2 --output oo2] ]
browserify main.js -p [./extractify.js --lazy [--entries foo1 --entries bar1 --output oo1]  ]
browserify main.js -p [./extractify.js --lazy [--entries foo1 --output oo1]  ]

```