### PR TITLE
Major refactoring required to work with actual proxy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,16 @@
 ---
+root: true
+extends: "eslint:recommended"
 env:
   node: true
-extend: "eslint:recommended"
+  es6: true
+  browser: true
+plugins:
+  - react
+parserOptions:
+  sourceType: module
+  ecmaFeatures:
+    jsx: true
 rules:
-  indent: [2, 4, {SwitchCase: 1}]
-  quotes: [2, 'single']
+  react/jsx-uses-vars: 2
+  no-console: 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extractify",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Browserify plugin to extract code to be lazy loaded into separate bundles",
   "repository": {
     "type": "git",
@@ -37,7 +37,6 @@
     "async": "^1.5.2",
     "shasum": "^1.0.2",
     "through2": "~2.0.1",
-    "watchify": "^3.7.0",
     "xtend": "^4.0.1"
   },
   "devDependencies": {
@@ -56,7 +55,8 @@
     "pre-commit": "^1.1.2",
     "react": "^0.14.5",
     "react-dom": "^0.14.5",
-    "tap": "^5.7.0"
+    "tap": "^5.7.0",
+    "watchify": "^3.7.0"
   },
   "pre-commit": [
     "lint",

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,10 +3,8 @@
    See the accompanying LICENSE file for terms. */
 
 var browserify = require('browserify');
-var tap = require('tap');
 var test = require('tap').test;
 var vm = require('vm');
-var path = require('path');
 
 test('basic', function (t) {
     t.plan(3);

--- a/test/bundle_map_options.js
+++ b/test/bundle_map_options.js
@@ -3,10 +3,8 @@
    See the accompanying LICENSE file for terms. */
 
 var browserify = require('browserify');
-var tap = require('tap');
 var test = require('tap').test;
 var vm = require('vm');
-var path = require('path');
 var xtend = require('xtend');
 var config = {
     lazy: [

--- a/test/files/dep4.js
+++ b/test/files/dep4.js
@@ -1,2 +1,2 @@
-var dummyDep1 = require('./dep1');
+var dummyDep1 = require('./dep1'); // eslint-disable-line
 module.exports = require('./dep5');

--- a/test/multi.js
+++ b/test/multi.js
@@ -3,10 +3,8 @@
    See the accompanying LICENSE file for terms. */
 
 var browserify = require('browserify');
-var tap = require('tap');
 var test = require('tap').test;
 var vm = require('vm');
-var path = require('path');
 
 test('multi', function (t) {
     t.plan(4);


### PR DESCRIPTION
## WHAT
To utilize main browserify's enties, plugins, options, etc.. thru actual proxy method in lazy browserifies, this major refactoring required. This is especially necessary to use the plugins registered in main bundle in lazy bundles.

## HOW
- Refactor main flow and separate action function into extractify prototype
- Remove extractify plugin in lazy bundles to prevent looping
- updated eslint rules
- Extra making external steps in lazyBundle